### PR TITLE
Include filename in output prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,18 +107,26 @@ function main() {
             username: host.user
         };
 
+        if (!host.user) {
+            connectionParams.username = host.user =
+                readlineSync.question('Username for ' + hostName + ':\n');
+        }
+
+        // Authentication Method
         if (host.password) {
             connectionParams.password = host.password;
         } else if (host.privateKey) {
             connectionParams.privateKey = host.privateKey;
-            if (host.privateKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') !== -1) {
-                connectionParams.passphrase =
+            if (host.passphrase) {
+                connectionParams.passphrase = host.passphrase;
+            } else if (host.privateKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') !== -1) {
+                connectionParams.passphrase = host.passphrase =
                     readlineSync.question('ssh key passphrase for ' + hostName + ':\n', {noEchoBack: true});
             }
         } else {
-            connectionParams.username = readlineSync.question('Username for ' + hostName + ':\n');
-            connectionParams.password = readlineSync.question('Password for ' + connectionParams.username +
-            '@' + hostName + ':\n', {noEchoBack: true});
+            var identifier = connectionParams.username + '@' + hostName;
+            connectionParams.password = host.password =
+                    readlineSync.question('Password for ' + identifier + ':\n', {noEchoBack: true});
         }
 
         conn.on('ready', readyCallback).connect(connectionParams);

--- a/index.js
+++ b/index.js
@@ -20,20 +20,6 @@ var osenv = require('osenv');
 var DEFAULT_CREDENTIALS_LOCATION = path.join(osenv.home(), '.remtail.json');
 
 
-/**
- * Builds an executable tail command
- *
- * @param {array} paths - an array of file paths to tail out
- */
-function buildTailCommand(paths) {
-    var command = 'tail';
-    paths.forEach(function(path) {
-        command += ' -F ' + path;
-    });
-    return command;
-}
-
-
 function printUsage() {
     console.log('usage: ');
     console.log('remtail hostname:/path/to/file hostname2:/path/to/file');
@@ -41,7 +27,6 @@ function printUsage() {
 
 
 function main() {
-
     if (args._.length === 0 || args.help) {
         printUsage();
         process.exit();
@@ -59,77 +44,88 @@ function main() {
     }
     hostUtils.addCredentials(hosts, credentialsMap);
 
-// open an ssh connection to every host and run the tail commands
+    // open an ssh connection to every host and run the tail commands
+    var connectionMap = {};
     var hostsSize = 0;
     for (var hostName in hosts) {
         hostsSize++;
         var host = hosts[hostName];
-        var tailCommand = buildTailCommand(host.paths);
-        console.log('hostname: ' + hostName);
-        console.log('command: ' + tailCommand);
 
-        var conn = new SshClient();
+        for (var i in host.paths) {
+            var filepath = host.paths[i];
+            var tailCommand = "tail -F " + filepath;
+            var filename = path.basename(filepath);
+            
+            console.log('hostname: ' + hostName);
+            console.log('command: ' + tailCommand);
 
-        // use bind to build a function that takes copies of local vars
-        // from this particular iteration of the for loop
-        var readyCallback = function (conn, tailCommand, hostName) {
-            var host = hosts[hostName];
-            conn.exec(tailCommand, function (err, stream) {
-                if (err) {
-                    throw err;
-                }
+            var conn = connectionMap[hostName] || new SshClient();
 
-                stream.on('close', function () {
-                    console.log('Connected closed to: ' + hostName);
-                    conn.end();
-                }).on('data', function (data) {
-                    var dataString = data.toString('utf-8');
-                    var lines = dataString.split('\n');
-                    lines.forEach(function (line) {
-                        if (line) {
-                            console.log(colors[host.color](hostName) + ' ' + line);
-                        }
-                    });
+            // use bind to build a function that takes copies of local vars
+            // from this particular iteration of the for loop
+            var readyCallback = function(conn, tailCommand, hostName, filename) {
+                var host = hosts[hostName];
+                conn.exec(tailCommand, function(err, stream) {
+                    if (err) {
+                        throw err;
+                    }
 
-                }).stderr.on('data', function (data) {
+                    stream.on('close', function() {
+                        console.log('Connected closed to: ' + hostName);
+                        conn.end();
+                    }).on('data', function(data) {
                         var dataString = data.toString('utf-8');
                         var lines = dataString.split('\n');
-                        lines.forEach(function (line) {
-                            console.log(hostName + ' ' + line);
+                        lines.forEach(function(line) {
+                            if (line) {
+                                console.log(colors[host.color](hostName + ' ' + filename) + ' ' + line);
+                            }
                         });
-                    });
-            });
-        }.bind(this, conn, tailCommand, hostName);
 
-        var connectionParams = {
-            host: hostName,
-            port: host.port,
-            username: host.user
-        };
+                    }).stderr.on('data', function(data) {
+                            var dataString = data.toString('utf-8');
+                            var lines = dataString.split('\n');
+                            lines.forEach(function(line) {
+                                console.log(hostName + ' ' + line);
+                            });
+                        });
+                });
+            }.bind(this, conn, tailCommand, hostName, filename);
+            conn.on('ready', readyCallback);
+            
+            if (!connectionMap[hostName]) {
+                var connectionParams = {
+                    host: hostName,
+                    port: host.port,
+                    username: host.user
+                };
 
-        if (!host.user) {
-            connectionParams.username = host.user =
-                readlineSync.question('Username for ' + hostName + ':\n');
-        }
+                if (!host.user) {
+                    connectionParams.username = host.user =
+                        readlineSync.question('Username for ' + hostName + ':\n');
+                }
 
-        // Authentication Method
-        if (host.password) {
-            connectionParams.password = host.password;
-        } else if (host.privateKey) {
-            connectionParams.privateKey = host.privateKey;
-            if (host.passphrase) {
-                connectionParams.passphrase = host.passphrase;
-            } else if (host.privateKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') !== -1) {
-                connectionParams.passphrase = host.passphrase =
-                    readlineSync.question('ssh key passphrase for ' + hostName + ':\n', {noEchoBack: true});
+                // Authentication Method
+                if (host.password) {
+                    connectionParams.password = host.password;
+                } else if (host.privateKey) {
+                    connectionParams.privateKey = host.privateKey;
+                    if (host.passphrase) {
+                        connectionParams.passphrase = host.passphrase;
+                    } else if (host.privateKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') !== -1) {
+                        connectionParams.passphrase = host.passphrase =
+                            readlineSync.question('ssh key passphrase for ' + hostName + ':\n', {noEchoBack: true});
+                    }
+                } else {
+                    var identifier = connectionParams.username + '@' + hostName;
+                    connectionParams.password = host.password =
+                        readlineSync.question('Password for ' + identifier + ':\n', {noEchoBack: true});
+                }
+
+                conn.connect(connectionParams);
+                connectionMap[hostName] = conn;
             }
-        } else {
-            var identifier = connectionParams.username + '@' + hostName;
-            connectionParams.password = host.password =
-                    readlineSync.question('Password for ' + identifier + ':\n', {noEchoBack: true});
         }
-
-        conn.on('ready', readyCallback).connect(connectionParams);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ function main() {
         var host = hosts[hostName];
 
         for (var i in host.paths) {
-            var filepath = host.paths[i];
-            var tailCommand = "tail -F " + filepath;
-            var filename = path.basename(filepath);
+            var file = host.paths[i];
+            var tailCommand = "tail -F " + file;
+            var displayPath = host.displayPaths[file];
             
             console.log('hostname: ' + hostName);
             console.log('command: ' + tailCommand);
@@ -63,7 +63,7 @@ function main() {
 
             // use bind to build a function that takes copies of local vars
             // from this particular iteration of the for loop
-            var readyCallback = function(conn, tailCommand, hostName, filename) {
+            var readyCallback = function(conn, tailCommand, hostName, displayPath) {
                 var host = hosts[hostName];
                 conn.exec(tailCommand, function(err, stream) {
                     if (err) {
@@ -78,7 +78,7 @@ function main() {
                         var lines = dataString.split('\n');
                         lines.forEach(function(line) {
                             if (line) {
-                                console.log(colors[host.color](hostName + ' ' + filename) + ' ' + line);
+                                console.log(colors[host.color](hostName + ' ' + displayPath) + ' ' + line);
                             }
                         });
 
@@ -86,11 +86,11 @@ function main() {
                             var dataString = data.toString('utf-8');
                             var lines = dataString.split('\n');
                             lines.forEach(function(line) {
-                                console.log(colors[host.color](hostName + ' ' + filename) + ' ' + line);
+                                console.log(colors[host.color](hostName + ' ' + displayPath) + ' ' + line);
                             });
                         });
                 });
-            }.bind(this, conn, tailCommand, hostName, filename);
+            }.bind(this, conn, tailCommand, hostName, displayPath);
             conn.on('ready', readyCallback);
             
             if (!connectionMap[hostName]) {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function main() {
                             var dataString = data.toString('utf-8');
                             var lines = dataString.split('\n');
                             lines.forEach(function(line) {
-                                console.log(hostName + ' ' + line);
+                                console.log(colors[host.color](hostName + ' ' + filename) + ' ' + line);
                             });
                         });
                 });

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -1,3 +1,61 @@
+var path = require('path');
+
+function buildDisplayPaths(hosts) {
+    for (var hostName in hosts) {
+        var host = hosts[hostName];
+        host.displayPaths = {};
+
+        if (host.paths.length > 1) {
+            var pathname = host.paths[0];
+            var ptr = 0,
+                startIndex = 0,
+                endIndex = 0;
+
+            while (ptr > -1) {
+                var matchString = pathname.substr(0, ptr);
+
+                var matched = host.paths.every(function(path) {
+                    return path.indexOf(matchString) == 0;
+                });
+
+                if (matched) {
+                    startIndex = ptr + 1;
+                } else {
+                    break;
+                }
+                
+                ptr = pathname.indexOf('/', ptr + 1);
+            }
+
+            while (ptr > -1) {
+                var matchString = pathname.substr(ptr);
+                console.log(matchString);
+                
+                var matched = host.paths.every(function(path) {
+                    return path.indexOf(matchString) == path.length - matchString.length;
+                });
+
+                if (matched) {
+                    endIndex = pathname.length - ptr;
+                    break;
+                }
+                
+                ptr = pathname.indexOf('/', ptr + 1);
+            }
+
+            host.paths.forEach(function(path) {
+                var length = path.length - endIndex;
+                var displayPath = path.substr(startIndex, length - startIndex);
+                host.displayPaths[path] = displayPath;
+            });
+        } else {
+            var pathname = host.paths[0];
+            hosts[hostName].displayPaths[pathname] = path.basename(pathname);
+        }
+    }
+}
+
+
 /**
  *
  * @param {string[]} hostPathPairs - an array of pairs like ['nickc@tst-web1:/var/log/httpd.log']
@@ -28,6 +86,8 @@ function buildHostMap(hostPathPairs) {
             }
         }
     });
+
+    buildDisplayPaths(hosts);
 
     return hosts;
 }
@@ -66,6 +126,7 @@ function addCredentials(hosts, credentialMap) {
 
 
 module.exports = {
+    buildDisplayPaths: buildDisplayPaths,
     buildHostMap: buildHostMap,
     addCredentials: addCredentials
 };

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,9 @@ var hostPathPairs = [
     'trillworks.com:/var/log/blah.log',
     'trillworks.com:/var/log/wow.log',
     'indeed.com:/var/www/django.log',
-    'yahoo.com:/var/log/whoa.log'
+    'yahoo.com:/var/log/whoa.log',
+    'github.com:/var/logs/app1/logs/application.log',
+    'github.com:/var/logs/test-app2/logs/application.log'
 ];
 var hostMap = hostUtils.buildHostMap(hostPathPairs);
 
@@ -23,15 +25,33 @@ test('build map of hosts from command line args', function (t) {
     var expectedHostMap = {
         'trillworks.com': {
             color: 'red',
-            paths: ['/var/log/blah.log', '/var/log/wow.log']
+            paths: ['/var/log/blah.log', '/var/log/wow.log'],
+            displayPaths: {
+                '/var/log/blah.log': 'blah.log',
+                '/var/log/wow.log': 'wow.log'
+            }
         },
         'indeed.com': {
             color: 'yellow',
-            paths: ['/var/www/django.log']
+            paths: ['/var/www/django.log'],
+            displayPaths: {
+                '/var/www/django.log': 'django.log'
+            }
         },
         'yahoo.com': {
             color: 'green',
-            paths: ['/var/log/whoa.log']
+            paths: ['/var/log/whoa.log'],
+            displayPaths: {
+                '/var/log/whoa.log': 'whoa.log'
+            }
+        },
+        'github.com': {
+            color: 'blue',
+            paths: ['/var/logs/app1/logs/application.log', '/var/logs/test-app2/logs/application.log'],
+            displayPaths: {
+                '/var/logs/app1/logs/application.log': 'app1',
+                '/var/logs/test-app2/logs/application.log': 'test-app2'
+            }
         }
     };
     t.deepEquals(hostMap, expectedHostMap);
@@ -70,21 +90,39 @@ test('add credentials to hosts map', function (t) {
             paths: ['/var/log/blah.log', '/var/log/wow.log'],
             user: 'bigtex',
             password: 'hunter2',
-            port: 22
+            port: 22,
+            displayPaths: {
+                '/var/log/blah.log': 'blah.log',
+                '/var/log/wow.log': 'wow.log'
+            }
         },
         'indeed.com': {
             color: 'yellow',
             paths: ['/var/www/django.log']   ,
             user: 'peter',
             password: 'blah',
-            port: 22
+            port: 22,
+            displayPaths: {
+                '/var/www/django.log': 'django.log'
+            }
         },
         'yahoo.com': {
             color: 'green',
             paths: ['/var/log/whoa.log'],
             privateKey: expectedPrivateKey,
             port: 22,
-            user: 'ganley'
+            user: 'ganley',
+            displayPaths: {
+                '/var/log/whoa.log': 'whoa.log'
+            }
+        },
+        'github.com': {
+            color: 'blue',
+            paths: ['/var/logs/app1/logs/application.log', '/var/logs/test-app2/logs/application.log'],
+            displayPaths: {
+                '/var/logs/app1/logs/application.log': 'app1',
+                '/var/logs/test-app2/logs/application.log': 'test-app2'
+            }
         }
     };
     t.deepEquals(hostMap, expectedHostMap);


### PR DESCRIPTION
I hate how this diff worked out.  Summary of change:
1. With a single tail command, there was no easy way to determine the source of the data chunk coming in.  To get the individual files, I broke it into multiple tail commands, but will re-use ssh connections for existing hosts.
2. Colors are still done on a per-host basis, but filenames are included in the colored prefix
3. Output is formatted as "[host] [filename] [content]", but I am open to an alternative format

Assigning to @NickCarneiro for review.
